### PR TITLE
Performance Improvement For IdPopulator

### DIFF
--- a/vesta-service/src/main/java/com/robert/vesta/service/impl/IdServiceImpl.java
+++ b/vesta-service/src/main/java/com/robert/vesta/service/impl/IdServiceImpl.java
@@ -2,10 +2,7 @@ package com.robert.vesta.service.impl;
 
 import com.robert.vesta.service.bean.Id;
 import com.robert.vesta.service.impl.bean.IdType;
-import com.robert.vesta.service.impl.populater.AtomicIdPopulator;
-import com.robert.vesta.service.impl.populater.IdPopulator;
-import com.robert.vesta.service.impl.populater.LockIdPopulator;
-import com.robert.vesta.service.impl.populater.SyncIdPopulator;
+import com.robert.vesta.service.impl.populater.*;
 import com.robert.vesta.util.CommonUtils;
 
 public class IdServiceImpl extends AbstractIdServiceImpl {
@@ -13,6 +10,8 @@ public class IdServiceImpl extends AbstractIdServiceImpl {
     private static final String SYNC_LOCK_IMPL_KEY = "vesta.sync.lock.impl.key";
 
     private static final String ATOMIC_IMPL_KEY = "vesta.atomic.impl.key";
+
+    private static final String CACHED_IMPL_KEY = "vesta.cached.impl.key";
 
     protected IdPopulator idPopulator;
 
@@ -43,7 +42,10 @@ public class IdServiceImpl extends AbstractIdServiceImpl {
         } else if (CommonUtils.isPropKeyOn(ATOMIC_IMPL_KEY)) {
             log.info("The AtomicIdPopulator is used.");
             idPopulator = new AtomicIdPopulator();
-        } else {
+        } else if (CommonUtils.isPropKeyOn(CACHED_IMPL_KEY) && idType == IdType.MAX_PEAK) {
+            log.info("The CachedIdPopulator is used");
+            idPopulator = new PerfIdPopulator();
+        }else {
             log.info("The default LockIdPopulator is used.");
             idPopulator = new LockIdPopulator();
         }

--- a/vesta-service/src/main/java/com/robert/vesta/service/impl/populater/PerfIdPopulator.java
+++ b/vesta-service/src/main/java/com/robert/vesta/service/impl/populater/PerfIdPopulator.java
@@ -1,0 +1,119 @@
+package com.robert.vesta.service.impl.populater;
+
+import com.robert.vesta.service.bean.Id;
+import com.robert.vesta.service.impl.bean.IdMeta;
+import com.robert.vesta.service.impl.bean.IdType;
+import com.robert.vesta.util.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PerfIdPopulator implements IdPopulator {
+
+    private static final Logger log = LoggerFactory.getLogger(PerfIdPopulator.class);
+
+    private volatile AtomicReference<IdElement> referenceIdElement;
+
+    private static long PEAK_SEQUENCE = 1000000L;
+
+    private final Timer timer;
+
+    private class IdElement {
+        private final long sequence;
+        private final long timeStamp;
+
+        public IdElement(long sequence, long timeStamp) {
+            this.sequence = sequence;
+            this.timeStamp = timeStamp;
+        }
+
+        public long getSequence() {
+            return sequence;
+        }
+
+        public long getTimeStamp() {
+            return timeStamp;
+        }
+
+        public boolean isOutOfSeq() {
+            return sequence >= PEAK_SEQUENCE;
+        }
+    }
+
+    public PerfIdPopulator() {
+        timer = new Timer();
+        long period = 1000L;
+        refreshAtomicIdElement();
+        timer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                long timestamp = TimeUtils.genTime(IdType.MAX_PEAK);
+                long lastTimestamp = referenceIdElement.get().getTimeStamp();
+                if (timestamp <= lastTimestamp) {
+                    log.error(String
+                            .format("Clock moved backwards.  Refusing to generate id for %d second/milisecond.",
+                                    lastTimestamp - timestamp));
+                    lockAtomicIdElement(lastTimestamp);
+                } else{
+                    refreshAtomicIdElement();
+                }
+            }
+        }, getNextSecond(), period);
+    }
+
+    private void lockAtomicIdElement(long lastTimestamp) {
+        referenceIdElement = new AtomicReference<IdElement>(new IdElement(PEAK_SEQUENCE,lastTimestamp));
+    }
+
+    public void populateId(Id id, IdMeta idMeta) {
+        IdElement idElement = getIdElement();
+        long sequence = idElement.getSequence();
+        sequence &= idMeta.getSeqBitsMask();
+        id.setSeq(sequence);
+        id.setTime(idElement.getTimeStamp());
+    }
+
+    private void refreshAtomicIdElement() {
+        long timestamp = TimeUtils.genTime(IdType.MAX_PEAK);
+        referenceIdElement = new AtomicReference<IdElement>(new IdElement(0L,timestamp));
+    }
+
+    private Date getNextSecond() {
+        Calendar now = Calendar.getInstance();
+        Calendar nextSecond = Calendar.getInstance();
+        nextSecond.set(
+                now.get(Calendar.YEAR),
+                now.get(Calendar.MONTH),
+                now.get(Calendar.DAY_OF_MONTH),
+                now.get(Calendar.HOUR_OF_DAY),
+                now.get(Calendar.MINUTE),
+                now.get(Calendar.SECOND)+1);
+        return nextSecond.getTime();
+    }
+
+    private IdElement getIdElement() {
+        while (referenceIdElement==null || referenceIdElement.get().isOutOfSeq()) { }
+
+        IdElement result;
+        while (true) {
+            result = referenceIdElement.get();
+            boolean isSet = referenceIdElement.compareAndSet(result, new IdElement(result.getSequence() + 1, result.getTimeStamp()));
+            if (isSet) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        timer.cancel();
+    }
+
+}

--- a/vesta-service/src/test/java/com/robert/vesta/service/impl/test/IdServicePerfTest.java
+++ b/vesta-service/src/test/java/com/robert/vesta/service/impl/test/IdServicePerfTest.java
@@ -1,12 +1,16 @@
 package com.robert.vesta.service.impl.test;
 
 import com.robert.vesta.service.intf.IdService;
+import com.sun.javafx.runtime.SystemProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class IdServicePerfTest {
 
     public static void main(String[] args) throws InterruptedException {
+        //System.getProperties().setProperty("vesta.cached.impl.key","true");
+        //System.getProperties().setProperty("vesta.atomic.impl.key","true");
+
         ApplicationContext ac = new ClassPathXmlApplicationContext(
                 "spring/vesta-service-test.xml");
 
@@ -59,10 +63,11 @@ public class IdServicePerfTest {
             }
         }
 
-        System.out.println("AVG(us): " + sum / 1000 / 1000000);
+        System.out.println("AVG(us): " + sum / 1000 / 1000000.0d);
         System.out.println("MAX(ms): " + max / 1000000);
 
         // Result is about 400,000 per second
+        System.exit(0);
     }
 
 }


### PR DESCRIPTION
This is a new implementation of IdPopulator, which can provide:
1. higher performance than AtomicIdPopulator, on my macbook air 2012, it offers 1/4 average response time, and 1/10 max response time
2. less CPU time than AtomicIdPopulator, on my macbook air 2012, it just use 9% CPU at peak, compared to AtimicIdPopulator will use 170% CPU rate 